### PR TITLE
Use python2 in the shebang of Python scripts

### DIFF
--- a/bin/morphologist
+++ b/bin/morphologist
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 import sys
 import optparse
 

--- a/morphologist/intra_analysis/commands/morphometry-concat.py
+++ b/morphologist/intra_analysis/commands/morphometry-concat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import re
 


### PR DESCRIPTION
For compatibility with systems where Python 3 is the default interpreter, see Task #14527 (https://bioproj.extra.cea.fr/redmine/issues/14527)